### PR TITLE
A0-2999: Run all workflows on node20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         toolchain: nightly-2024-02-09
         components: rustfmt, clippy
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Check format


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.